### PR TITLE
Use a single windowClickHandler function in lifecycle

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,14 +99,15 @@ MenuDroppoComponent.prototype.manageListeners = function() {
 
 MenuDroppoComponent.prototype.componentDidMount = function() {
   if (this) {
-    window.addEventListener('click', this.windowWasClicked.bind(this))
+    this.windowClickHandler = this.windowWasClicked.bind(this);
+    window.addEventListener('click', this.windowClickHandler)
     var container = findDOMNode(this)
     this.container = container
   }
 }
 
 MenuDroppoComponent.prototype.componentWillUnmount = function() {
-  window.removeEventListener('click', this.windowWasClicked.bind(this))
+  window.removeEventListener('click', this.windowClickHandler)
 }
 
 MenuDroppoComponent.prototype.windowWasClicked = function(event) {


### PR DESCRIPTION
This PR fixes an issue where `menu-droppo` checks for a dropdown container that is already unmounted. It is needed for the WIP Options Menu PR, on [my fork of MetaMask](https://github.com/sdtsui/metamask-plugin/pull/1/files).

Please see the supplementary review below for more details.