### PR TITLE
Refactor global click listener to target document instead of window

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,19 +70,21 @@ MenuDroppoComponent.prototype.manageListeners = function() {
 }
 
 MenuDroppoComponent.prototype.componentDidMount = function() {
-  if (this) {
-    this.windowClickHandler = this.windowWasClicked.bind(this);
-    window.addEventListener('click', this.windowClickHandler)
+  if (this && document.body) {
+    this.globalClickHandler = this.globalClickOccurred.bind(this);
+    document.body.addEventListener('click', this.globalClickHandler)
     var container = findDOMNode(this)
     this.container = container
   }
 }
 
 MenuDroppoComponent.prototype.componentWillUnmount = function() {
-  window.removeEventListener('click', this.windowClickHandler)
+  if (this && document.body) {
+    document.body.removeEventListener('click', this.globalClickHandler)
+  }
 }
 
-MenuDroppoComponent.prototype.windowWasClicked = function(event) {
+MenuDroppoComponent.prototype.globalClickOccurred = function(event) {
   const target = event.target
   const container = findDOMNode(this)
   const isOpen = this.props.isOpen


### PR DESCRIPTION
See [metamask-extension/1831](https://github.com/MetaMask/metamask-extension/pull/1831).

If this is merged, please mention me somewhere and I can bump the version in `metamask/NewUI` as well.